### PR TITLE
feat: add home-manager module

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Flake implements xremap features that allow specifying per-application remapping
 `**`: Hyprland feature can be enabled, but the service cannot find a socket
 
 # How to use
-## As a module
+## On NixOS
 
 1. Add following to your `flake.nix`:
 
@@ -32,6 +32,20 @@ Flake implements xremap features that allow specifying per-application remapping
 
 2. Import the `xremap-flake.nixosModules.default` module.
 3. Configure the [module options](#Configuration)
+
+## Using home-manager on non-NixOS system
+1. Add following to your `flake.nix`:
+
+    ```nix
+    {
+        inputs.xremap-flake.url = "github:xremap/nix-flake";
+    }
+    ```
+
+2. Import the `xremap-flake.homeManagerModules.default` module.
+3. Set the [module options](#Configuration) without the user-related settings. This will create a systemd user service with xremap.
+
+## Any other configuration
 
 Alternatively, one of the flake packages (see `nix flake show github:xremap/nix-flake`) can be used with `nix run` to launch xremap with the corresponding feature.
 

--- a/flake.nix
+++ b/flake.nix
@@ -111,6 +111,7 @@
           };
         flake = {
           nixosModules.default = importApply ./modules { localFlake = self; inherit withSystem; };
+          homeManagerModules.default = importApply ./homeManagerModules { localFlake = self; inherit withSystem; };
           nixosConfigurations = import ./nixosConfigurations { localFlake = self; inherit inputs; };
         };
       }

--- a/homeManagerModules/default.nix
+++ b/homeManagerModules/default.nix
@@ -1,0 +1,25 @@
+{ localFlake, withSystem }:
+{ config, pkgs, lib, ... }:
+let
+  cfg = config.services.xremap;
+  commonModuleObject = import ../modules/common.nix { inherit pkgs lib cfg localFlake; };
+  inherit (commonModuleObject) configFile;
+in
+{
+  options.services.xremap = commonModuleObject.commonOptions;
+  config = {
+    systemd.user.services.xremap = {
+      Unit = {
+        Description = "xremap service";
+        PartOf = [ "graphical-session.target" ];
+        After = [ "graphical-session.target" ];
+      };
+      Service = {
+        Type = "simple";
+        ExecStart = "${lib.getExe cfg.package} ${if cfg.deviceName != "" then "--device \"${cfg.deviceName}\"" else ""} ${if cfg.watch then "--watch" else ""} ${configFile}";
+        Restart = "always";
+      };
+      Install.WantedBy = [ "graphical-session.target" ];
+    };
+  };
+}

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -1,0 +1,95 @@
+# Function that produces common things to reuse across modules
+{ pkgs, lib, cfg, localFlake }:
+let
+  packages' = localFlake.packages.${pkgs.stdenv.hostPlatform.system};
+in
+{
+  configFile = pkgs.writeTextFile {
+    name = "xremap-config.yml";
+    text =
+      assert ((cfg.yamlConfig == "" && cfg.config != { }) || (cfg.yamlConfig != "" && cfg.config == { }));
+      if cfg.yamlConfig == "" then pkgs.lib.generators.toYAML { } cfg.config else cfg.yamlConfig;
+  };
+  commonOptions = with lib; {
+    withSway = mkEnableOption "support for Sway";
+    withGnome = mkEnableOption "support for Gnome";
+    withX11 = mkEnableOption "support for X11";
+    withHypr = mkEnableOption "support for Hyprland";
+    package = mkOption {
+      type = types.package;
+      default =
+        if cfg.withSway then
+          packages'.xremap-sway
+        else if cfg.withGnome then
+          packages'.xremap-gnome
+        else if cfg.withX11 then
+          packages'.xremap-x11
+        else if cfg.withHypr then
+          packages'.xremap-hypr
+        else
+          packages'.xremap
+      ;
+    };
+    config = mkOption {
+      type = types.attrs;
+      description = "Xremap configuration. See xremap repo for examples. Cannot be used together with .yamlConfig";
+      default = { };
+      example = ''
+        {
+          modmap = [
+            {
+              name = "Global",
+              remap = {
+                CapsLock = "Esc";
+                Ctrl_L = "Esc";
+              };
+            }
+          ];
+          keymap = [
+            {
+              name = "Default (Nocturn, etc.)",
+              application = {
+              not = [ "Google-chrome", "Slack", "Gnome-terminal", "jetbrains-idea"];
+              };
+              remap = {
+                # Emacs basic
+                "C-b" = "left";
+                "C-f" = "right";
+              };
+            }
+          ];
+        }
+      '';
+    };
+    yamlConfig = mkOption {
+      type = types.str;
+      default = "";
+      description = ''
+        The text of yaml config file for xremap. See xremap repo for examples. Cannot be used together with .config.
+      '';
+      example = ''
+        modmap:
+          - name: Except Chrome
+            application:
+              not: Google-chrome
+            remap:
+              CapsLock: Esc
+        keymap:
+          - name: Emacs binding
+            application:
+              only: Slack
+            remap:
+              C-b: left
+              C-f: right
+              C-p: up
+              C-n: down
+      '';
+    };
+    deviceName = mkOption {
+      type = types.str;
+      default = "";
+      description = "Device name which xremap will remap. If not specified - xremap will remap all devices.";
+    };
+    watch = mkEnableOption "running xremap watching new devices";
+  };
+}


### PR DESCRIPTION
This commit adds a new output to the flake called "homeManagerModules". This output contains a home manager module that configures xremap on a non-NixOS system which is managed through home-manager module.

`nix flake check` marks homeManagerModules as an unknown output since it's not standard, but some projects (e.g. Hyprland) are using this schema.

Should a common naming approach be codified -- homeManagerModules output will be deprecated.

Closes #20