### PR TITLE
feat: expose .debug option

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Following `services.xremap` options are exposed:
 * `deviceName` – the name of the device to be used. To find out the name, you can check `/proc/bus/input/devices`
 * `watch` – whether to watch for new devices
 * `mouse` – whether to watch for mice by default
+* `debug` – enables debug logging for xremap
 
 See examples in `nixosConfigurations` inside flake.nix.
 

--- a/homeManagerModules/default.nix
+++ b/homeManagerModules/default.nix
@@ -4,6 +4,7 @@ let
   cfg = config.services.xremap;
   localLib = localFlake.localLib { inherit pkgs lib cfg; };
   inherit (localLib) mkExecStart configFile;
+  inherit (lib) optionalString;
 in
 {
   options.services.xremap = localLib.commonOptions;
@@ -18,6 +19,7 @@ in
         Type = "simple";
         ExecStart = mkExecStart configFile;
         Restart = "always";
+        Environment = optionalString cfg.debug "RUST_LOG=debug";
       };
       Install.WantedBy = [ "graphical-session.target" ];
     };

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -108,6 +108,7 @@ in
       example = [ "--completions zsh" ];
       description = "Extra arguments for xremap";
     };
+    debug = mkEnableOption "run xremap with RUST_LOG=debug in case upstream needs logs";
   };
   configFile = pkgs.writeTextFile {
     name = "xremap-config.yml";

--- a/modules/system-service.nix
+++ b/modules/system-service.nix
@@ -4,6 +4,7 @@
 let
   cfg = config.services.xremap;
   userPath = "/run/user/${toString cfg.userId}";
+  inherit (lib) optionalString;
 in
 {
   systemd.services.xremap = lib.mkIf (cfg.serviceMode == "system") {
@@ -11,6 +12,7 @@ in
     path = [ cfg.package ];
     wantedBy = [ "multi-user.target" ];
     serviceConfig = {
+      Environment = optionalString cfg.debug "RUST_LOG=debug";
       PrivateNetwork = true;
       MemoryDenyWriteExecute = true;
       CapabilityBoundingSet = [ "~CAP_SETUID" "~CAP_SETGID" "~CAP_SETPCAP" "~CAP_SYS_ADMIN" "~CAP_SYS_PTRACE" "~CAP_NET_ADMIN" "~CAP_FOWNER" "~CAP_IPC_OWNER" "~CAP_SYS_TIME" "~CAP_KILL" "~CAP_SYS_BOOT" "~CAP_LINUX_IMMUTABLE" "~CAP_IPC_LOCK" "~CAP_SYS_CHROOT" "~CAP_BLOCK_SUSPEND" "~CAP_SYS_PACCT" "~CAP_WAKE_ALARM" "~CAP_AUDIT_WRITE" "~CAP_AUDIT_CONTROL" "~CAP_AUDIT_READ" "CAP_DAC_READ_SEARCH" "CAP_DAC_OVERRIDE" ];

--- a/modules/user-service.nix
+++ b/modules/user-service.nix
@@ -2,6 +2,7 @@
 { pkgs, lib, config, ... }:
 
 let
+  inherit (lib) optionalString;
   cfg = config.services.xremap;
 in
 {
@@ -48,7 +49,7 @@ in
         LockPersonality = true;
         UMask = "077";
         RestrictAddressFamilies = "AF_UNIX";
-        # Environment = "RUST_LOG=debug";
+        Environment = optionalString cfg.debug "RUST_LOG=debug";
         ExecStart = mkExecStart configFile;
       };
     };


### PR DESCRIPTION
The new option allows running xremap with upstream's debug logging enabled