### PR TITLE
feat: add `options.xremap.enable` to determine whether the service should actually run

### DIFF
--- a/homeManagerModules/default.nix
+++ b/homeManagerModules/default.nix
@@ -4,11 +4,11 @@ let
   cfg = config.services.xremap;
   localLib = localFlake.localLib { inherit pkgs lib cfg; };
   inherit (localLib) mkExecStart configFile;
-  inherit (lib) optionalString;
+  inherit (lib) mkIf optionalString;
 in
 {
   options.services.xremap = localLib.commonOptions;
-  config = {
+  config = mkIf cfg.enable {
     systemd.user.services.xremap = {
       Unit = {
         Description = "xremap service";

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -14,6 +14,11 @@ in
     withHypr = mkEnableOption "support for Hyprland (consider switching to wlroots)";
     withWlroots = mkEnableOption "support for wlroots-based compositors (Sway, Hyprland, etc.)";
     withKDE = mkEnableOption "support KDE-Plasma Wayland";
+    enable = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Enable xremap service";
+    };
     package = mkOption {
       type = types.package;
       default =

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -6,7 +6,8 @@ let
   cfg = config.services.xremap;
   localLib = localFlake.localLib { inherit pkgs lib cfg; };
   inherit (localLib) mkExecStart configFile;
-in with lib; {
+in
+with lib; {
   imports = [
     (import ./user-service.nix { inherit mkExecStart configFile; })
     (import ./system-service.nix { inherit mkExecStart configFile; })

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -6,18 +6,12 @@ let
   cfg = config.services.xremap;
   localLib = localFlake.localLib { inherit pkgs lib cfg; };
   inherit (localLib) mkExecStart configFile;
-in
-with lib; {
+in with lib; {
   imports = [
     (import ./user-service.nix { inherit mkExecStart configFile; })
     (import ./system-service.nix { inherit mkExecStart configFile; })
   ];
   options.services.xremap = {
-    enable = mkOption {
-      type = types.bool;
-      default = true;
-      description = "Enable xremap service";
-    };
     serviceMode = mkOption {
       type = types.enum [ "user" "system" ];
       default = "system";

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -13,6 +13,11 @@ with lib; {
     (import ./system-service.nix { inherit mkExecStart configFile; })
   ];
   options.services.xremap = {
+    enable = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Enable xremap service";
+    };
     serviceMode = mkOption {
       type = types.enum [ "user" "system" ];
       default = "system";

--- a/modules/system-service.nix
+++ b/modules/system-service.nix
@@ -7,7 +7,7 @@ let
   inherit (lib) optionalString;
 in
 {
-  systemd.services.xremap = lib.mkIf (cfg.serviceMode == "system") {
+  systemd.services.xremap = lib.mkIf (cfg.enable && cfg.serviceMode == "system") {
     description = "xremap system service";
     path = [ cfg.package ];
     wantedBy = [ "multi-user.target" ];

--- a/modules/system-service.nix
+++ b/modules/system-service.nix
@@ -4,10 +4,10 @@
 let
   cfg = config.services.xremap;
   userPath = "/run/user/${toString cfg.userId}";
-  inherit (lib) optionalString;
+  inherit (lib) mkIf optionalString;
 in
 {
-  systemd.services.xremap = lib.mkIf (cfg.enable && cfg.serviceMode == "system") {
+  systemd.services.xremap = mkIf (cfg.enable && cfg.serviceMode == "system") {
     description = "xremap system service";
     path = [ cfg.package ];
     wantedBy = [ "multi-user.target" ];

--- a/modules/user-service.nix
+++ b/modules/user-service.nix
@@ -6,7 +6,7 @@ let
   cfg = config.services.xremap;
 in
 {
-  config = lib.mkIf (cfg.serviceMode == "user") {
+  config = lib.mkIf (cfg.enable && cfg.serviceMode == "user") {
     hardware.uinput.enable = true;
     /* services.udev.extraRules = */
     /*   '' */

--- a/modules/user-service.nix
+++ b/modules/user-service.nix
@@ -2,11 +2,11 @@
 { pkgs, lib, config, ... }:
 
 let
-  inherit (lib) optionalString;
+  inherit (lib) mkIf optionalString;
   cfg = config.services.xremap;
 in
 {
-  config = lib.mkIf (cfg.enable && cfg.serviceMode == "user") {
+  config = mkIf (cfg.enable && cfg.serviceMode == "user") {
     hardware.uinput.enable = true;
     /* services.udev.extraRules = */
     /*   '' */


### PR DESCRIPTION
currently, if you import the module, the service gets automatically defined and enabled.

this is not in line with how most services are defined, usually they have a `services.<service>.enable` option that determines whether the service should be running.

i have added that option, to allow determining whether the service should run.

i would have preferred to use a `lib.mkEnableOption` rather than `lib.mkOption`, so that it can be more inline with how most services are defined, but i didn't want my PR to break existing configs when they update, so i set it to default to `true`, so the current behavior isn't changed.

if you don't mind changing the default behavior, i can update this PR to use `lib.mkEnableOption` instead.

this closes #64 