### PR TITLE
refactor: allow user to add env vars to hm service

### DIFF
--- a/homeManagerModules/default.nix
+++ b/homeManagerModules/default.nix
@@ -9,7 +9,7 @@ let
   cfg = config.services.xremap;
   localLib = localFlake.localLib { inherit pkgs lib cfg; };
   inherit (localLib) mkExecStart configFile;
-  inherit (lib) mkIf optionalString;
+  inherit (lib) mkIf optionalAttrs;
 in
 {
   options.services.xremap = localLib.commonOptions;
@@ -24,8 +24,7 @@ in
         Type = "simple";
         ExecStart = mkExecStart configFile;
         Restart = "always";
-        Environment = optionalString cfg.debug "RUST_LOG=debug";
-      };
+      } // optionalAttrs cfg.debug { Environment = [ "RUST_LOG=debug" ]; };
       Install.WantedBy = [ "graphical-session.target" ];
     };
   };


### PR DESCRIPTION
The current implementation of he `debug` option disallows the user to
add environment variables --- `Environment=<NAME>=<VALUE>` to the xremap
service, without using `lib.mkForce`, which causes to user to need to
pass `RUST_LOG=debug` manually.

This happens because a string is used, instead of a list of strings,
which may be appended, allowing the user to pass new environment
variables without disregarding the `debug` option.

By moving the effect of the `debug` option ---
`Environment=RUST_LOG=debug` to an optional attribute set which uses a
list of strings instead of a string, we allow users to add environment
variables to the xremap systemd service.
