### PR TITLE
fix: order xremap user unit after graphical-session.target

### DIFF
--- a/modules/user-service.nix
+++ b/modules/user-service.nix
@@ -21,7 +21,7 @@ in
       path = [ cfg.package ];
       # NOTE: xremap needs DISPLAY:, WAYLAND_DISPLAY: and a bunch of other stuff in the environment to launch graphical applications (launch:)
       # On Gnome after gnome-session.target is up - those variables are populated
-      after = lib.mkIf cfg.withGnome [ "gnome-session.target" ];
+      after = [ "graphical-session.target" ] ++ (lib.optional cfg.withGnome "gnome-session.target");
       wantedBy = [ "graphical-session.target" ];
       serviceConfig = mkMerge [
         {


### PR DESCRIPTION
This should start xremap after a WM starts, initializing the socket address.

In practice this fixes application-specific maps not working when xremap user service starts initially

Fixes #97